### PR TITLE
[custom hooks]: implement useFiniteStateMachine

### DIFF
--- a/src/api/addNounAPI.js
+++ b/src/api/addNounAPI.js
@@ -17,7 +17,7 @@ const addNounAPI = (props) => {
     }
   };
   console.log(nounDE, article, nounPL);
-  client
+  return client
     .query(
       q.Create(q.Collection('nouns'), {
         data: {
@@ -27,10 +27,13 @@ const addNounAPI = (props) => {
         },
       })
     )
-    .then((response) => {
+    .then(() => {
       console.log('api post');
-      return response;
+      return true;
     })
-    .catch((error) => console.log('Error: ', error.message));
+    .catch((error) => {
+      console.log('Error: ', error.message);
+      return false;
+    });
 };
 export default addNounAPI;

--- a/src/components/form/AddWordToDB.js
+++ b/src/components/form/AddWordToDB.js
@@ -19,6 +19,7 @@ const initialRef = {
 
 const AddWordToDB = () => {
   const ctx = useContext(DictionaryContext);
+  const currentState = ctx.currentState;
   const inputRef = useRef(initialRef);
   const formRef = useRef(null);
   const focusRef = useRef(null);
@@ -39,6 +40,7 @@ const AddWordToDB = () => {
 
   return (
     <AddWordForm onSubmit={saveWord} ref={formRef}>
+      <p>{currentState}</p>
       <FormField
         label="Your word"
         name="nounDE"

--- a/src/hooks/useFiniteStateMachine.js
+++ b/src/hooks/useFiniteStateMachine.js
@@ -1,0 +1,41 @@
+import { useState } from 'react';
+
+const states = {
+  empty: 'empty',
+  isLoading: 'loading',
+  hasLoaded: 'loaded',
+  hasError: 'error',
+};
+
+const transitions = {
+  [states.empty]: {
+    FETCH_DATA: states.isLoading,
+  },
+  [states.isLoading]: {
+    FETCH_DATA_SUCCESS: states.hasLoaded,
+    FETCH_DATA_ERROR: states.hasError,
+  },
+  [states.hasLoaded]: {
+    FETCH_DATA: states.isLoading,
+  },
+  [states.hasError]: {
+    FETCH_DATA: states.isLoading,
+  },
+};
+
+function useFiniteStateMachine() {
+  const [currentState, setCurrentState] = useState('empty');
+
+  const transition = (currentState, action) => {
+    const nextState = transitions[currentState][action];
+    return nextState || currentState;
+  };
+
+  const updateState = (action) => {
+    setCurrentState((currentState) => transition(currentState, action));
+  };
+
+  return [currentState, updateState];
+}
+
+export default useFiniteStateMachine;


### PR DESCRIPTION
	- hook is handling with the state and  can be used in each of API requests implemented in the app
[providers]:
	- implement hook useFiniteStateMachine (handle API's requests states)
	- remove unused code
[api]: modify addNounAPI to handle with state machine hook
	- addNounAPI returns Promise instead of data or value; returned Promise is managed in the DictionaryProvider
[components]: import currentState to the AddWordToDB
[delete]: delete unused useAuth file (empty, not used at all)