### PR TITLE
[providers]: simplify DictionaryProvider:

### DIFF
--- a/src/api/getNounsAPI.js
+++ b/src/api/getNounsAPI.js
@@ -6,7 +6,18 @@ const getNounsAPI = () =>
   client
     .query(q.Paginate(q.Match(q.Ref(endpoint)), { size: 100000 }))
     .then((response) => {
-      return response.data;
+      let parsedData = [],
+        index = 0;
+      for (let item of response.data) {
+        parsedData[index] = {
+          nounDE: item[0],
+          article: item[1],
+          nounPL: item[2],
+          id: item[3],
+        };
+        index++;
+      }
+      return parsedData;
     })
     .catch((error) => console.log('Error: ', error.message));
 

--- a/src/components/dictionary/DisplayDictionary.js
+++ b/src/components/dictionary/DisplayDictionary.js
@@ -10,16 +10,15 @@ const DisplayDictionary = () => {
     ctx.setLocalStorage();
   }, []);
 
-  const getDictionary = (e) => {
-    e.preventDefault();
-    ctx.getData();
-  };
-
   return (
     <>
-      <StyledButton as="button" onClick={getDictionary}>
-        Load your dictionary
-      </StyledButton>
+      <ul>
+        {!ctx.localDictionary ? (
+          <p>{ctx.currentState}</p>
+        ) : (
+          ctx.localDictionary.map((item) => <li key={item.id}>{item.id}</li>)
+        )}
+      </ul>
     </>
   );
 };

--- a/src/components/game/DisplayGame.js
+++ b/src/components/game/DisplayGame.js
@@ -10,16 +10,15 @@ const DisplayGame = () => {
     ctx.setLocalStorage();
   }, []);
 
-  const getNouns = (e) => {
-    e.preventDefault();
-    ctx.getData();
-  };
-
   return (
     <>
-      <StyledButton as="button" onClick={getNouns}>
-        Play game
-      </StyledButton>
+      <ul>
+        {!ctx.localDictionary ? (
+          <p>{ctx.currentState}</p>
+        ) : (
+          ctx.localDictionary.map((item) => <li key={item.id}>{item.id}</li>)
+        )}
+      </ul>
     </>
   );
 };


### PR DESCRIPTION
	- remove getData method (setLocalStorage is doing that)
[api]: modify getNounsAPI
	- faunadb index was changed and now returns directly ids for article and current noun
	- after fetch all nouns in one chunk, all items are parsed into new array parsedData which stores obcjects for each of nouns
	- method returns parsedData, which allows app to handle better fetched nouns later on
[components]:
	- formulate for DisplayDictionary and DisplayGame frame for handling DictionaryProvider