### PR TITLE
[store data locally]: change localStorage into sessionStorage in the app

### DIFF
--- a/src/components/dictionary/DisplayDictionary.js
+++ b/src/components/dictionary/DisplayDictionary.js
@@ -7,7 +7,7 @@ const DisplayDictionary = () => {
   const ctx = useContext(DictionaryContext);
 
   useEffect(() => {
-    ctx.setLocalStorage();
+    ctx.setsessionStorage();
   }, []);
 
   const getDictionary = (e) => {

--- a/src/components/game/DisplayGame.js
+++ b/src/components/game/DisplayGame.js
@@ -7,7 +7,7 @@ const DisplayGame = () => {
   const ctx = useContext(DictionaryContext);
 
   useEffect(() => {
-    ctx.setLocalStorage();
+    ctx.setsessionStorage();
   }, []);
 
   const getNouns = (e) => {

--- a/src/providers/DictionaryProvider.js
+++ b/src/providers/DictionaryProvider.js
@@ -21,7 +21,7 @@ const mockupDictionary = [
 export const DictionaryContext = React.createContext({
   addData: () => {},
   getData: () => {},
-  setLocalStorage: () => {},
+  setsessionStorage: () => {},
   currentState: '',
 });
 
@@ -52,22 +52,25 @@ export const DictionaryProvider = ({ children }) => {
     });
   };
 
-  const setLocalStorage = () => {
-    if (!window.localStorage.getItem(storageItemName))
+  const setsessionStorage = () => {
+    if (!window.sessionStorage.getItem(storageItemName))
       getData().then((response) => {
-        window.localStorage.setItem(storageItemName, JSON.stringify(response));
+        window.sessionStorage.setItem(
+          storageItemName,
+          JSON.stringify(response)
+        );
         return setLocalDictionary(
-          JSON.parse(window.localStorage.getItem(storageItemName))
+          JSON.parse(window.sessionStorage.getItem(storageItemName))
         );
       });
     return setLocalDictionary(
-      JSON.parse(window.localStorage.getItem(storageItemName))
+      JSON.parse(window.sessionStorage.getItem(storageItemName))
     );
   };
 
   return (
     <DictionaryContext.Provider
-      value={{ addData, getData, setLocalStorage, currentState }}
+      value={{ addData, getData, setsessionStorage, currentState }}
     >
       {children}
     </DictionaryContext.Provider>


### PR DESCRIPTION
	- reason: as long as the user is logging from diffirent devices or browser, he can chagne the database - so better is to fetch fresh data from the server each time user is opening the browser